### PR TITLE
[Codegen] Resolve constantOp with multiple layouts users.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -345,19 +345,25 @@ static OpOperand &getOpOperand(Operation *op, unsigned operandLatticeIndex) {
   llvm::report_fatal_error("No vector operand found");
 }
 
-/// Get a layout if all the given layouts are same. If all layouts are not same,
-/// return nullptr.
+/// Get a layout if all the given initialized layouts are same.
+/// If any initialized layouts are not same, return nullptr.
 static const DistributionLayout *
 getAgreedLayout(ArrayRef<const DistributionLayout *> layouts) {
-  if (layouts.empty())
+  SmallVector<const DistributionLayout *> initializedLayouts;
+  for (auto layout : layouts) {
+    if (layout->isUninitialized())
+      continue;
+    initializedLayouts.push_back(layout);
+  }
+
+  if (initializedLayouts.empty())
     return nullptr;
 
   // Check if all layouts are same.
-  if (!llvm::all_equal(llvm::make_pointee_range(layouts))) {
+  if (!llvm::all_equal(llvm::make_pointee_range(initializedLayouts)))
     return nullptr;
-  }
 
-  return layouts[0];
+  return initializedLayouts[0];
 }
 
 /// Hueristic to use to choose the best layout when enforcing the same layout
@@ -1029,8 +1035,8 @@ LogicalResult VectorLayoutAnalysis::run() {
   // The order of loading matters here, because propagateLayout does anchoring
   // initialization which needs the lattice to know both enforcement and
   // propagation.
-  solver.load<EnforceLayout>(root->getContext());
   solver.load<PropagateLayout>(anchors, root->getContext());
+  solver.load<EnforceLayout>(root->getContext());
   return solver.initializeAndRun(root);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -208,6 +208,19 @@ DistributionLayout::doResolution(const VectorLayoutInterface &rhs) {
 
 ChangeResult DistributionLayout::resolveWithPossibleConflict(
     const VectorLayoutInterface &rhs, OpOperand &opOperand) {
+
+  IRRewriter builder(opOperand.getOwner());
+  // Handle case where constantOp may have multiple consumers with different
+  // layouts by creating a copy of constOp for other users.
+  if (!opOperand.get().hasOneUse() && !vectorLayout &&
+      llvm::dyn_cast_or_null<arith::ConstantOp>(
+          opOperand.get().getDefiningOp())) {
+    Operation *copiedConstOp = builder.clone(*opOperand.get().getDefiningOp());
+    Value copiedConst = copiedConstOp->getResult(0);
+    builder.replaceAllUsesExcept(opOperand.get(), copiedConst,
+                                 opOperand.getOwner());
+  }
+
   ResolutionResult result = doResolution(rhs);
 
   // If there is no conflict, simply return.
@@ -220,7 +233,6 @@ ChangeResult DistributionLayout::resolveWithPossibleConflict(
 
   // Resolve conflict by create an operation that takes the input the conflicted
   // value and returns the resolved value.
-  OpBuilder builder(opOperand.getOwner());
   Value input = opOperand.get();
   // Create a resolution operation. This conflict should be handeled later by
   // someone else, not this analysis.

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -117,8 +117,11 @@ private:
 
 class EnforceLayout : public DataFlowAnalysis {
 public:
-  explicit EnforceLayout(DataFlowSolver &solver, MLIRContext *ctx)
-      : DataFlowAnalysis(solver), ctx(ctx) {}
+  explicit EnforceLayout(
+      DataFlowSolver &solver,
+      DenseMap<TypedValue<VectorType>, VectorLayoutInterface> &anchors,
+      MLIRContext *ctx)
+      : DataFlowAnalysis(solver), anchors(anchors), ctx(ctx) {}
 
   LogicalResult initialize(Operation *root) override;
 
@@ -136,6 +139,8 @@ private:
                              MutableArrayRef<OpOperand> operands);
 
   DistributionLayout *getLatticeElement(Value val);
+
+  DenseMap<TypedValue<VectorType>, VectorLayoutInterface> anchors;
 
   MLIRContext *ctx;
 };
@@ -776,7 +781,7 @@ void enforcementTransferFunction(
 /// ==========================================================================
 
 LogicalResult PropagateLayout::initialize(Operation *root) {
-  // Set layout for anchor ops.
+  // Set layout for anchor ops or resolve if need be.
   for (auto [val, layout] : anchors) {
     DistributionLayout *latticeEl = getLatticeElement(val);
     ChangeResult changed = latticeEl->resolve(layout);
@@ -905,6 +910,13 @@ DistributionLayout *PropagateLayout::getLatticeElement(Value val) {
 /// ==========================================================================
 
 LogicalResult EnforceLayout::initialize(Operation *root) {
+  // Set layout for anchor ops or resolve if need be.
+  for (auto [val, layout] : anchors) {
+    DistributionLayout *latticeEl = getLatticeElement(val);
+    ChangeResult changed = latticeEl->resolve(layout);
+    propagateIfChanged(latticeEl, changed);
+  }
+
   root->walk([&](Operation *traversed) { visitOperation(traversed); });
   return success();
 }
@@ -1036,7 +1048,7 @@ LogicalResult VectorLayoutAnalysis::run() {
   // initialization which needs the lattice to know both enforcement and
   // propagation.
   solver.load<PropagateLayout>(anchors, root->getContext());
-  solver.load<EnforceLayout>(root->getContext());
+  solver.load<EnforceLayout>(anchors, root->getContext());
   return solver.initializeAndRun(root);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -196,8 +196,8 @@ builtin.module attributes { transform.with_named_sequence } {
 // redundant to_layout ops that convert elemwise ops to the 2nd layout
 // prematurely. Especially useful during chained contraction cases.
 
-#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 8]>>
-#layoutB = #iree_vector_ext.layout<<[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 8]>, <[BATCHY, LANEX], [2, 32]>>
+#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>
+#layoutB = #iree_vector_ext.layout<<[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>, <[BATCHY, LANEX], [2, 32]>>
 #layoutC = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>
 
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>


### PR DESCRIPTION
Main motivation is to handle distribution of constantOp who has users
with different layouts.

Original use case is to ensure we can distribute attention when the tile
size for M,K1,N is the same. Which means the init of 1st contract, and
IV's init uses the same constantOp.

Since constantOp can only hold a single layout, but multiple to_layout ops
with different layouts,  for each user, there will be non resolved to_layout
op(s). only one of the to_layout op can be  resolved properly, the rest would
be a "non trivial" resolution since layouts are different.

To solve this issue, we introduce a mechanism that detect these cases
and make a copy of the arith.constant that get used by other users, when
we are trying to resolve for the current constantOp.